### PR TITLE
avoid buffering of STDOUT

### DIFF
--- a/script/harriet
+++ b/script/harriet
@@ -11,6 +11,7 @@ my %orig_env = %ENV;
 my $harriet = Harriet->new($dir);
 $harriet->load_all();
 
+$| = 1;
 print "\n\n";
 while (my ($k, $v) = each %ENV) {
     unless (exists $orig_env{$k}) {


### PR DESCRIPTION
I want to read STDOUT of `harriet` command via a pipe (e.g. https://github.com/shogo82148/go-prove/pull/5), but there is nothing to output.

```
$ harriet t/harriet | cat
# nothing to output
```
