### PR TITLE
specify default script path to `./t/harriet/` for removes dot from @INC

### DIFF
--- a/lib/App/Prove/Plugin/Harriet.pm
+++ b/lib/App/Prove/Plugin/Harriet.pm
@@ -7,7 +7,7 @@ use Harriet;
 sub load {
     my ($class, $p) = @_;
     my @args = @{ $p->{args} };
-    my $dir = shift @args || 't/harriet/';
+    my $dir = shift @args || './t/harriet/';
     my $harriet = Harriet->new($dir);
     $harriet->load_all();
 }
@@ -24,7 +24,7 @@ App::Prove::Plugin::Harriet - Harriet with prove
 =head1 SYNOPSIS
 
     # in your .proverc
-    -PHarriet=t/harriet/
+    -PHarriet=./t/harriet/
 
 =head1 DESCRIPTION
 

--- a/lib/Harriet.pm
+++ b/lib/Harriet.pm
@@ -49,7 +49,7 @@ Harriet - Daemon manager for testing
 
     use Harriet;
 
-    my $harriet = Harriet->new('t/harriet/');
+    my $harriet = Harriet->new('./t/harriet/');
     $harriet->load('stf');
     print $ENV{TEST_STF}, "\n";
 
@@ -99,7 +99,7 @@ This code runs memcached. It returns memcached's end point information and guard
 
     use Harriet;
 
-    my $harriet = Harriet->new('t/harriet');
+    my $harriet = Harriet->new('./t/harriet');
     $harriet->load('memcached');
     print $ENV{memcached}, "\n";
 
@@ -109,7 +109,7 @@ harriet loads harriet script named 't/harriet/memcached.pl'.
 =head2 Save daemon process under the prove
 
     # .proverc
-    -PHarriet=t/harriet/
+    -PHarriet=./t/harriet/
 
 L<App::Prove::Plugin::Harriet> loads harriet scripts under the C<t/harriet/>, and set these to environment variables.
 


### PR DESCRIPTION
In Perl 5.24.1 and newer releases, core modules and tool scripts removed `.` from `@INC`.
`App::Prove::Plugin::Harriet`'s default path cannot loading in the new `prove`.